### PR TITLE
fix: bundle generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,15 @@ LOCAL_BIN_PATH := ${PROJECT_PATH}/bin
 
 ADDON_PATH := ${PROJECT_PATH}/addons/connectors-operator
 
+STRIMZI_BUNDLE_NAME  := strimzi-kafka-operator
+CAMEL_K_BUNDLE_NAME  := camel-k-operator
+CAMEL_BUNDLE_NAME 	 := cos-fleetshard-operator-camel
+DEBEZIUM_BUNDLE_NAME := cos-fleetshard-operator-debezium
+SYNC_BUNDLE_NAME 	 := cos-fleetshard-sync
+
 OPERATOR_SDK_VERSION := v1.17.0
+
+PREVIOUS_TAG := $(shell ./hack/fetch-previous-tag.sh)
 
 export PATH := ${LOCAL_BIN_PATH}:$(PATH)
 
@@ -17,48 +25,65 @@ bundles: bundle/camel-k bundle/strimzi bundle/cos-fleetshard-sync bundle/cos-fle
 bundle/camel-k: operator-sdk
 	./hack/bundle.sh \
 		"camel-k" \
-		"camel-k-operator" \
-		"camel-k-operator/$(ADDON_VERSION)"
+		"$(CAMEL_K_BUNDLE_NAME)" \
+		"$(CAMEL_K_BUNDLE_NAME)/$(ADDON_VERSION)" \
+		"stable"
 
 bundle/strimzi: operator-sdk
 	./hack/bundle.sh \
 		"strimzi" \
-		"strimzi-kafka-operator" \
-		"strimzi-kafka-operator/$(ADDON_VERSION)"
+		"$(STRIMZI_BUNDLE_NAME)" \
+		"$(STRIMZI_BUNDLE_NAME)/$(ADDON_VERSION)" \
+		"alpha"
 
 bundle/cos-fleetshard-operator-camel: operator-sdk
 	./hack/bundle.sh \
-		"cos-fleetshard-operator-camel" \
-		"cos-fleetshard-operator-camel" \
-		"cos-fleetshard-operator-camel/$(ADDON_VERSION)"
-	
+		"$(CAMEL_BUNDLE_NAME)" \
+		"$(CAMEL_BUNDLE_NAME)" \
+		"$(CAMEL_BUNDLE_NAME)/$(ADDON_VERSION)" \
+		"stable"
+		
 	cp hack/templates/operator-dependencies.yaml \
 		$(ADDON_PATH)/cos-fleetshard-operator-camel/$(ADDON_VERSION)/metadata/dependencies.yaml
 	
-	yq -i '.dependencies[0].value.packageName="camel-k"' \
+	yq -i '.dependencies[0].value.packageName="$(CAMEL_K_BUNDLE_NAME)"' \
 		$(ADDON_PATH)/cos-fleetshard-operator-camel/$(ADDON_VERSION)/metadata/dependencies.yaml
 	yq -i '.dependencies[0].value.version=strenv(ADDON_VERSION)' \
 		$(ADDON_PATH)/cos-fleetshard-operator-camel/$(ADDON_VERSION)/metadata/dependencies.yaml
+
+	yq -i 'del(.status)' \
+		$(ADDON_PATH)/cos-fleetshard-operator-camel/$(ADDON_VERSION)/manifests/cos-fleetshard-operator-camel_v1_service.yaml
+		
+	yq -i '.spec.replaces="$(CAMEL_BUNDLE_NAME).$(PREVIOUS_TAG)"' \
+			$(ADDON_PATH)/cos-fleetshard-operator-camel/$(ADDON_VERSION)/manifests/cos-fleetshard-operator-camel.clusterserviceversion.yaml
 
 bundle/cos-fleetshard-operator-debezium: operator-sdk
 	./hack/bundle.sh \
-		"cos-fleetshard-operator-debezium" \
-		"cos-fleetshard-operator-debezium" \
-		"cos-fleetshard-operator-debezium/$(ADDON_VERSION)"
+		"$(DEBEZIUM_BUNDLE_NAME)" \
+		"$(DEBEZIUM_BUNDLE_NAME)" \
+		"$(DEBEZIUM_BUNDLE_NAME)/$(ADDON_VERSION)" \
+		"stable"
 
 	cp hack/templates/operator-dependencies.yaml \
 		$(ADDON_PATH)/cos-fleetshard-operator-debezium/$(ADDON_VERSION)/metadata/dependencies.yaml
 
-	yq -i '.dependencies[0].value.packageName="strimzi"' \
+	yq -i '.dependencies[0].value.packageName="$(STRIMZI_BUNDLE_NAME)"' \
 		$(ADDON_PATH)/cos-fleetshard-operator-debezium/$(ADDON_VERSION)/metadata/dependencies.yaml
 	yq -i '.dependencies[0].value.version=strenv(ADDON_VERSION)' \
 		$(ADDON_PATH)/cos-fleetshard-operator-debezium/$(ADDON_VERSION)/metadata/dependencies.yaml
 
+	yq -i 'del(.status)' \
+		$(ADDON_PATH)/cos-fleetshard-operator-debezium/$(ADDON_VERSION)/manifests/cos-fleetshard-operator-debezium_v1_service.yaml
+
+	yq -i '.spec.replaces="$(DEBEZIUM_BUNDLE_NAME).$(PREVIOUS_TAG)"' \
+			$(ADDON_PATH)/cos-fleetshard-operator-debezium/$(ADDON_VERSION)/manifests/cos-fleetshard-operator-debezium.clusterserviceversion.yaml
+
 bundle/cos-fleetshard-sync: operator-sdk
 	./hack/bundle.sh \
-		"cos-fleetshard-sync" \
-		"cos-fleetshard-sync" \
-		main/$(ADDON_VERSION)
+		"$(SYNC_BUNDLE_NAME)" \
+		"$(SYNC_BUNDLE_NAME)" \
+		main/$(ADDON_VERSION) \
+		"stable"
 
 	cp hack/templates/config.yaml \
 		$(ADDON_PATH)/main
@@ -70,8 +95,14 @@ bundle/cos-fleetshard-sync: operator-sdk
 	yq -i '.dependencies[1].value.version=strenv(ADDON_VERSION)' \
 		$(ADDON_PATH)/main/$(ADDON_VERSION)/metadata/dependencies.yaml
 
+	yq -i 'del(.status)' \
+		$(ADDON_PATH)/main/$(ADDON_VERSION)/manifests/cos-fleetshard-sync_v1_service.yaml
+
+	yq -i '.spec.replaces="$(SYNC_BUNDLE_NAME).$(PREVIOUS_TAG)"' \
+			$(ADDON_PATH)/main/$(ADDON_VERSION)/manifests/cos-fleetshard-sync.clusterserviceversion.yaml
+
 #
-# Heleprs
+# Helpers
 #
 
 operator-sdk:
@@ -93,9 +124,10 @@ ifeq (, $(shell command -v operator-sdk 2> /dev/null))
 endif
 
 #
-# Heleprs
+# Helpers
 #
 
+.PHONY: bundle/init
 .PHONY: bundle/camel-k 
 .PHONY: bundle/strimzi
 .PHONY: cos-fleetshard-sync

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -16,6 +16,7 @@ export BUNDLE_BASE=$(dirname "${BASH_SOURCE[0]}")/..
 export BUNDLE_ID="${1}"
 export BUNDLE_NAME="${2}"
 export BUNDLE_DIR="${3}"
+export BUNDLE_CHANNEL="${4}"
 export DIR_OVERLAY="${BUNDLE_BASE}/kustomize/overlays/${ADDON_OVERLAY}/data-plane/${BUNDLE_ID}"
 export DIR_ADDON="${BUNDLE_BASE}/addons/connectors-operator/${BUNDLE_DIR}"
 
@@ -30,12 +31,13 @@ echo "# version : ${ADDON_VERSION}"
 echo "# dir     : ${BUNDLE_DIR}"
 echo "# package : ${BUNDLE_NAME}"
 echo "# base    : ${BUNDLE_BASE}"
+echo "# channel : ${BUNDLE_CHANNEL}"
 echo "##############################################"
 
 kustomize build "${DIR_OVERLAY}" | operator-sdk generate bundle \
     --package "${BUNDLE_NAME}" \
-    --channels stable \
-    --default-channel stable \
+    --channels ${BUNDLE_CHANNEL} \
+    --default-channel ${BUNDLE_CHANNEL} \
     --output-dir "${DIR_ADDON}" \
     --version "${ADDON_VERSION}" \
     --kustomize-dir "${DIR_OVERLAY}"

--- a/hack/fetch-previous-tag.sh
+++ b/hack/fetch-previous-tag.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+git fetch --tags
+git tag | tr - \~ | sort -V | tr \~ - | tail -2 | head -1 2>/dev/null


### PR DESCRIPTION
- Compute `replaces` field by using previous tag version.
- Use alpha channel for strimzi operator.
- Fix camel and debezium dependencies package names.
- Delete generated `status` field from `Service` resources.