### PR TITLE
Use same addon version for all bundles

### DIFF
--- a/hack/fetch-previous-tag.sh
+++ b/hack/fetch-previous-tag.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+git fetch --tags
+git tag | tr - \~ | sort -V | tr \~ - | tail -2 | head -1 2>/dev/null


### PR DESCRIPTION
- apply ADDON_VERSION to all bundles, including Camel-K and Strimzi
- add `cos.bf2.org/underlying-version` annotation to Camel-K and Strimzi with the actual underlying operator version
- add `replaces` field to all CSV, which serves only as a way to forcibly use an specific addon version by modifying the `startingCSV` field of the `Subscription`. otherwise, the latest version of the addon will be installed because of skipRange

The already existing 1.1.10 bundles were used to test this new version of the generator.