### PR TITLE
fix: force kameletbindings CRD replacement

### DIFF
--- a/kustomize/overlays/dev/data-plane/kustomization.yaml
+++ b/kustomize/overlays/dev/data-plane/kustomization.yaml
@@ -1,5 +1,9 @@
 resources:
   - https://github.com/bf2fc6cc711aee1a0c2a/cos-fleetshard//etc/kubernetes/manifests/overlays/dev
+
+patchesStrategicMerge:
+  - patches/argocd-crds-kameletbindings.yaml
+
 images:
   - name: quay.io/rhoas/cos-fleetshard-operator-camel
     digest: sha256:31d7a8f677f3808a6f981c31cfb584e3c3540814184ca11149d61ba21249b514

--- a/kustomize/overlays/dev/data-plane/patches/argocd-crds-kameletbindings.yaml
+++ b/kustomize/overlays/dev/data-plane/patches/argocd-crds-kameletbindings.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kameletbindings.camel.apache.org
+  annotations:
+    argocd.argoproj.io/sync-options: Replace=true


### PR DESCRIPTION
As today, ArgoCD fails to sync the resources because of 

```
one or more objects failed to apply, reason: CustomResourceDefinition.apiextensions.k8s.io
"kameletbindings.camel.apache.org" is invalid: metadata.annotations: Too long: must have at
most 262144 bytes
```

The issue is mentioned [upstream](https://github.com/argoproj/argo-cd/issues/820) and the current workaround is to force the replacement of the offending resource. 

As long term solution, we [should use server side apply](https://github.com/bf2fc6cc711aee1a0c2a/cos-manifests/issues/224) but this is not yet available in ArgoCD
